### PR TITLE
Unpin conda-build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 


### PR DESCRIPTION
Tacks on to PR ( https://github.com/conda-forge/opencv-feedstock/pull/16 ). Unpins `conda-build` on Travis CI to avoid issues with bad packages created by the `conda`/`conda-build` version compatibility differential. See this issue ( https://github.com/conda-forge/hdf5-feedstock/issues/23 ) for an example of this problem. While we haven't seen this problem for awhile (and are unclear why), we are still cautious with this pinning.
