### PR TITLE
Add Python tweaks for Python

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -52,11 +52,37 @@ cmake .. -LAH -G "NMake Makefiles"                                             ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%                                    ^
     -DEXECUTABLE_OUTPUT_PATH=%LIBRARY_BIN%                                     ^
     -DLIBRARY_OUTPUT_PATH=%LIBRARY_BIN%                                        ^
-    -DPYTHON%PY_MAJOR%_EXECUTABLE=%PREFIX%\python                              ^
-    -DPYTHON_INCLUDE_DIR=%PREFIX%\include                                      ^
-    -DPYTHON_PACKAGES_PATH=%SP_DIR%                                            ^
-    -DPYTHON_LIBRARY=%PREFIX%\libs\%PY_LIB%                                    ^
-    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%SP_DIR%\numpy\core\include
+    -DPYTHON_EXECUTABLE=""                                                     ^
+    -DPYTHON_INCLUDE_DIR=""                                                    ^
+    -DPYTHON_PACKAGES_PATH=""                                                  ^
+    -DPYTHON_LIBRARY=""                                                        ^
+    -DPYTHON_NUMPY_INCLUDE_DIRS=""                                             ^
+    -DBUILD_opencv_python2=0                                                   ^
+    -DPYTHON2_EXECUTABLE=""                                                    ^
+    -DPYTHON2_INCLUDE_DIR=""                                                   ^
+    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                            ^
+    -DPYTHON2_LIBRARY=""                                                       ^
+    -DPYTHON2_PACKAGES_PATH=""                                                 ^
+    -DBUILD_opencv_python3=0                                                   ^
+    -DPYTHON3_EXECUTABLE=""                                                    ^
+    -DPYTHON3_INCLUDE_DIR=""                                                   ^
+    -DPYTHON3_NUMPY_INCLUDE_DIRS=""                                            ^
+    -DPYTHON3_LIBRARY=""                                                       ^
+    -DPYTHON3_PACKAGES_PATH=""
+if errorlevel 1 exit 1
+
+cmake .. -LAH -G "NMake Makefiles"                                         ^
+    -DPYTHON_EXECUTABLE=%PREFIX%\python                                    ^
+    -DPYTHON_INCLUDE_DIR=%PREFIX%\include                                  ^
+    -DPYTHON_PACKAGES_PATH=%SP_DIR%                                        ^
+    -DPYTHON_LIBRARY=%PREFIX%\libs\%PY_LIB%                                ^
+    -DPYTHON_NUMPY_INCLUDE_DIRS=%SP_DIR%\numpy\core\include                ^
+    -DBUILD_opencv_python%PY_MAJOR%=1                                      ^
+    -DPYTHON%PY_MAJOR%_EXECUTABLE=%PREFIX%\python                          ^
+    -DPYTHON%PY_MAJOR%_INCLUDE_DIR=%PREFIX%\include                        ^
+    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%SP_DIR%\numpy\core\include      ^
+    -DPYTHON%PY_MAJOR%_LIBRARY=%PREFIX%\libs\%PY_LIB%                      ^
+    -DPYTHON%PY_MAJOR%_PACKAGES_PATH=%SP_DIR%
 if errorlevel 1 exit 1
 
 cmake --build . --target INSTALL --config Release

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,13 @@
 @echo ON
+setlocal enabledelayedexpansion
 
 curl -L -O "https://github.com/opencv/opencv_contrib/archive/%PKG_VERSION%.tar.gz"
 %PYTHON% -c "import tarfile, os; tar = tarfile.open(os.environ['PKG_VERSION'] + '.tar.gz', 'r:gz'); tar.extractall(); tar.close()"
+%PYTHON% -c "import hashlib, os; print(hashlib.sha256(open(os.environ['PKG_VERSION'] + '.tar.gz', 'rb').read()).hexdigest())" > sha256.out
+SET /p CONTRIB_SHA256=<sha256.out
+if NOT "%CONTRIB_SHA256%" == "ef2084bcd4c3812eb53c21fa81477d800e8ce8075b68d9dedec90fef395156e5" (
+    exit 1
+)
 
 rem Patches apply only to opencv_contrib so we have to apply them now (after source download above)
 rem Fixed: https://github.com/opencv/opencv_contrib/blob/6cd8e9f556c8c55c05178dec05d5277ae00020d9/modules/tracking/src/trackerKCF.cpp#L669
@@ -29,12 +35,14 @@ for /F "tokens=1,2 delims=. " %%a in ("%PY_VER%") do (
 )
 set PY_LIB=python%PY_MAJOR%%PY_MINOR%.lib
 
+
 :: CMake/OpenCV like Unix-style paths for some reason.
-UNIX_PREFIX=%PREFIX:\=/%
-UNIX_LIBRARY_PREFIX=%LIBRARY_PREFIX:\=/%
-UNIX_LIBRARY_BIN=%LIBRARY_BIN:\=/%
-UNIX_SP_DIR=%SP_DIR:\=/%
-UNIX_SRC_DIR=%SRC_DIR:\=/%
+set UNIX_PREFIX=%PREFIX:\=/%
+set UNIX_LIBRARY_PREFIX=%LIBRARY_PREFIX:\=/%
+set UNIX_LIBRARY_BIN=%LIBRARY_BIN:\=/%
+set UNIX_SP_DIR=%SP_DIR:\=/%
+set UNIX_SRC_DIR=%SRC_DIR:\=/%
+
 
 cmake .. -LAH -G "NMake Makefiles"                                                  ^
     -DWITH_EIGEN=1                                                                  ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -47,7 +47,7 @@ cmake .. -LAH -G "NMake Makefiles"                                             ^
     -DWITH_FFMPEG=0                                                            ^
     -DWITH_VTK=0                                                               ^
     -DINSTALL_C_EXAMPLES=0                                                     ^
-    -DOPENCV_EXTRA_MODULES_PATH=%SRC_DIR%\opencv_contrib-%PKG_VERSION%\modules ^
+    -DOPENCV_EXTRA_MODULES_PATH=%SRC_DIR%/opencv_contrib-%PKG_VERSION%/modules ^
     -DCMAKE_BUILD_TYPE="Release"                                               ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%                                    ^
     -DEXECUTABLE_OUTPUT_PATH=%LIBRARY_BIN%                                     ^
@@ -72,16 +72,16 @@ cmake .. -LAH -G "NMake Makefiles"                                             ^
 if errorlevel 1 exit 1
 
 cmake .. -LAH -G "NMake Makefiles"                                         ^
-    -DPYTHON_EXECUTABLE=%PREFIX%\python                                    ^
-    -DPYTHON_INCLUDE_DIR=%PREFIX%\include                                  ^
+    -DPYTHON_EXECUTABLE=%PREFIX%/python                                    ^
+    -DPYTHON_INCLUDE_DIR=%PREFIX%/include                                  ^
     -DPYTHON_PACKAGES_PATH=%SP_DIR%                                        ^
-    -DPYTHON_LIBRARY=%PREFIX%\libs\%PY_LIB%                                ^
-    -DPYTHON_NUMPY_INCLUDE_DIRS=%SP_DIR%\numpy\core\include                ^
+    -DPYTHON_LIBRARY=%PREFIX%/libs/%PY_LIB%                                ^
+    -DPYTHON_NUMPY_INCLUDE_DIRS=%SP_DIR%/numpy/core/include                ^
     -DBUILD_opencv_python%PY_MAJOR%=1                                      ^
-    -DPYTHON%PY_MAJOR%_EXECUTABLE=%PREFIX%\python                          ^
-    -DPYTHON%PY_MAJOR%_INCLUDE_DIR=%PREFIX%\include                        ^
-    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%SP_DIR%\numpy\core\include      ^
-    -DPYTHON%PY_MAJOR%_LIBRARY=%PREFIX%\libs\%PY_LIB%                      ^
+    -DPYTHON%PY_MAJOR%_EXECUTABLE=%PREFIX%/python                          ^
+    -DPYTHON%PY_MAJOR%_INCLUDE_DIR=%PREFIX%/include                        ^
+    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%SP_DIR%/numpy/core/include      ^
+    -DPYTHON%PY_MAJOR%_LIBRARY=%PREFIX%/libs/%PY_LIB%                      ^
     -DPYTHON%PY_MAJOR%_PACKAGES_PATH=%SP_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,60 +29,67 @@ for /F "tokens=1,2 delims=. " %%a in ("%PY_VER%") do (
 )
 set PY_LIB=python%PY_MAJOR%%PY_MINOR%.lib
 
-cmake .. -LAH -G "NMake Makefiles"                                             ^
-    -DWITH_EIGEN=1                                                             ^
-    -DBUILD_TESTS=0                                                            ^
-    -DBUILD_DOCS=0                                                             ^
-    -DBUILD_PERF_TESTS=0                                                       ^
-    -DBUILD_ZLIB=0                                                             ^
-    -DBUILD_opencv_bioinspired=0                                               ^
-    -DBUILD_TIFF=0                                                             ^
-    -DBUILD_PNG=0                                                              ^
-    -DBUILD_OPENEXR=1                                                          ^
-    -DBUILD_JASPER=1                                                           ^
-    -DBUILD_JPEG=0                                                             ^
-    -DWITH_CUDA=0                                                              ^
-    -DWITH_OPENCL=0                                                            ^
-    -DWITH_OPENNI=0                                                            ^
-    -DWITH_FFMPEG=0                                                            ^
-    -DWITH_VTK=0                                                               ^
-    -DINSTALL_C_EXAMPLES=0                                                     ^
-    -DOPENCV_EXTRA_MODULES_PATH=%SRC_DIR%/opencv_contrib-%PKG_VERSION%/modules ^
-    -DCMAKE_BUILD_TYPE="Release"                                               ^
-    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%                                    ^
-    -DEXECUTABLE_OUTPUT_PATH=%LIBRARY_BIN%                                     ^
-    -DLIBRARY_OUTPUT_PATH=%LIBRARY_BIN%                                        ^
-    -DPYTHON_EXECUTABLE=""                                                     ^
-    -DPYTHON_INCLUDE_DIR=""                                                    ^
-    -DPYTHON_PACKAGES_PATH=""                                                  ^
-    -DPYTHON_LIBRARY=""                                                        ^
-    -DPYTHON_NUMPY_INCLUDE_DIRS=""                                             ^
-    -DBUILD_opencv_python2=0                                                   ^
-    -DPYTHON2_EXECUTABLE=""                                                    ^
-    -DPYTHON2_INCLUDE_DIR=""                                                   ^
-    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                            ^
-    -DPYTHON2_LIBRARY=""                                                       ^
-    -DPYTHON2_PACKAGES_PATH=""                                                 ^
-    -DBUILD_opencv_python3=0                                                   ^
-    -DPYTHON3_EXECUTABLE=""                                                    ^
-    -DPYTHON3_INCLUDE_DIR=""                                                   ^
-    -DPYTHON3_NUMPY_INCLUDE_DIRS=""                                            ^
-    -DPYTHON3_LIBRARY=""                                                       ^
+:: CMake/OpenCV like Unix-style paths for some reason.
+UNIX_PREFIX=%PREFIX:\=/%
+UNIX_LIBRARY_PREFIX=%LIBRARY_PREFIX:\=/%
+UNIX_LIBRARY_BIN=%LIBRARY_BIN:\=/%
+UNIX_SP_DIR=%SP_DIR:\=/%
+UNIX_SRC_DIR=%SRC_DIR:\=/%
+
+cmake .. -LAH -G "NMake Makefiles"                                                  ^
+    -DWITH_EIGEN=1                                                                  ^
+    -DBUILD_TESTS=0                                                                 ^
+    -DBUILD_DOCS=0                                                                  ^
+    -DBUILD_PERF_TESTS=0                                                            ^
+    -DBUILD_ZLIB=0                                                                  ^
+    -DBUILD_opencv_bioinspired=0                                                    ^
+    -DBUILD_TIFF=0                                                                  ^
+    -DBUILD_PNG=0                                                                   ^
+    -DBUILD_OPENEXR=1                                                               ^
+    -DBUILD_JASPER=1                                                                ^
+    -DBUILD_JPEG=0                                                                  ^
+    -DWITH_CUDA=0                                                                   ^
+    -DWITH_OPENCL=0                                                                 ^
+    -DWITH_OPENNI=0                                                                 ^
+    -DWITH_FFMPEG=0                                                                 ^
+    -DWITH_VTK=0                                                                    ^
+    -DINSTALL_C_EXAMPLES=0                                                          ^
+    -DOPENCV_EXTRA_MODULES_PATH=%UNIX_SRC_DIR%/opencv_contrib-%PKG_VERSION%/modules ^
+    -DCMAKE_BUILD_TYPE="Release"                                                    ^
+    -DCMAKE_INSTALL_PREFIX=%UNIX_LIBRARY_PREFIX%                                    ^
+    -DEXECUTABLE_OUTPUT_PATH=%UNIX_LIBRARY_BIN%                                     ^
+    -DLIBRARY_OUTPUT_PATH=%UNIX_LIBRARY_BIN%                                        ^
+    -DPYTHON_EXECUTABLE=""                                                          ^
+    -DPYTHON_INCLUDE_DIR=""                                                         ^
+    -DPYTHON_PACKAGES_PATH=""                                                       ^
+    -DPYTHON_LIBRARY=""                                                             ^
+    -DPYTHON_NUMPY_INCLUDE_DIRS=""                                                  ^
+    -DBUILD_opencv_python2=0                                                        ^
+    -DPYTHON2_EXECUTABLE=""                                                         ^
+    -DPYTHON2_INCLUDE_DIR=""                                                        ^
+    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                                 ^
+    -DPYTHON2_LIBRARY=""                                                            ^
+    -DPYTHON2_PACKAGES_PATH=""                                                      ^
+    -DBUILD_opencv_python3=0                                                        ^
+    -DPYTHON3_EXECUTABLE=""                                                         ^
+    -DPYTHON3_INCLUDE_DIR=""                                                        ^
+    -DPYTHON3_NUMPY_INCLUDE_DIRS=""                                                 ^
+    -DPYTHON3_LIBRARY=""                                                            ^
     -DPYTHON3_PACKAGES_PATH=""
 if errorlevel 1 exit 1
 
-cmake .. -LAH -G "NMake Makefiles"                                         ^
-    -DPYTHON_EXECUTABLE=%PREFIX%/python                                    ^
-    -DPYTHON_INCLUDE_DIR=%PREFIX%/include                                  ^
-    -DPYTHON_PACKAGES_PATH=%SP_DIR%                                        ^
-    -DPYTHON_LIBRARY=%PREFIX%/libs/%PY_LIB%                                ^
-    -DPYTHON_NUMPY_INCLUDE_DIRS=%SP_DIR%/numpy/core/include                ^
-    -DBUILD_opencv_python%PY_MAJOR%=1                                      ^
-    -DPYTHON%PY_MAJOR%_EXECUTABLE=%PREFIX%/python                          ^
-    -DPYTHON%PY_MAJOR%_INCLUDE_DIR=%PREFIX%/include                        ^
-    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%SP_DIR%/numpy/core/include      ^
-    -DPYTHON%PY_MAJOR%_LIBRARY=%PREFIX%/libs/%PY_LIB%                      ^
-    -DPYTHON%PY_MAJOR%_PACKAGES_PATH=%SP_DIR%
+cmake .. -LAH -G "NMake Makefiles"                                                  ^
+    -DPYTHON_EXECUTABLE=%UNIX_PREFIX%/python                                        ^
+    -DPYTHON_INCLUDE_DIR=%UNIX_PREFIX%/include                                      ^
+    -DPYTHON_PACKAGES_PATH=%UNIX_SP_DIR%                                            ^
+    -DPYTHON_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                                    ^
+    -DPYTHON_NUMPY_INCLUDE_DIRS=%UNIX_SP_DIR%/numpy/core/include                    ^
+    -DBUILD_opencv_python%PY_MAJOR%=1                                               ^
+    -DPYTHON%PY_MAJOR%_EXECUTABLE=%UNIX_PREFIX%/python                              ^
+    -DPYTHON%PY_MAJOR%_INCLUDE_DIR=%UNIX_PREFIX%/include                            ^
+    -DPYTHON%PY_MAJOR%_NUMPY_INCLUDE_DIRS=%UNIX_SP_DIR%/numpy/core/include          ^
+    -DPYTHON%PY_MAJOR%_LIBRARY=%UNIX_PREFIX%/libs/%PY_LIB%                          ^
+    -DPYTHON%PY_MAJOR%_PACKAGES_PATH=%UNIX_SP_DIR%
 if errorlevel 1 exit 1
 
 cmake --build . --target INSTALL --config Release

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -49,7 +49,20 @@ cmake .. -LAH                                                             \
     -DOPENCV_EXTRA_MODULES_PATH="../opencv_contrib-$PKG_VERSION/modules"  \
     -DCMAKE_BUILD_TYPE="Release"                                          \
     -DCMAKE_SKIP_RPATH:bool=ON                                            \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX
+    -DCMAKE_INSTALL_PREFIX=$PREFIX                                        \
+    -DBUILD_opencv_python2=0                                              \
+    -DPYTHON2_EXECUTABLE=""                                               \
+    -DPYTHON2_INCLUDE_DIR=""                                              \
+    -DPYTHON2_NUMPY_INCLUDE_DIRS=""                                       \
+    -DPYTHON2_LIBRARY=""                                                  \
+    -DPYTHON_INCLUDE_DIR2=""                                              \
+    -DPYTHON2_PACKAGES_PATH=""                                            \
+    -DBUILD_opencv_python3=0                                              \
+    -DPYTHON3_EXECUTABLE=""                                               \
+    -DPYTHON3_NUMPY_INCLUDE_DIRS=""                                       \
+    -DPYTHON3_INCLUDE_DIR=""                                              \
+    -DPYTHON3_LIBRARY=""                                                  \
+    -DPYTHON3_PACKAGES_PATH=""
 
 if [ $PY3K -eq 1 ]; then
     PY_VER_M="${PY_VER}m"
@@ -61,7 +74,6 @@ if [ $PY3K -eq 1 ]; then
         -DPYTHON_LIBRARY="${LIB_PYTHON}"                                    \
         -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                  \
         -DBUILD_opencv_python3=1                                            \
-        -DBUILD_opencv_python2=0                                            \
         -DPYTHON3_EXECUTABLE=${PYTHON}                                      \
         -DPYTHON3_NUMPY_INCLUDE_DIRS=${SP_DIR}/numpy/core/include           \
         -DPYTHON3_INCLUDE_DIR=${PREFIX}/include/python${PY_VER_M}           \
@@ -74,7 +86,6 @@ else
         -DPYTHON_INCLUDE_DIR="${INC_PYTHON}"                                \
         -DPYTHON_LIBRARY="${LIB_PYTHON}"                                    \
         -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                  \
-        -DBUILD_opencv_python3=0                                            \
         -DBUILD_opencv_python2=1                                            \
         -DPYTHON2_EXECUTABLE=${PYTHON}                                      \
         -DPYTHON2_INCLUDE_DIR=$PREFIX/include/python${PY_VER}               \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -70,8 +70,10 @@ PY_MAJOR="${PY_VER_ARR[0]}"
 
 if [ $PY3K -eq 1 ]; then
     LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}m.${DYNAMIC_EXT}"
+    INC_PYTHON="$PREFIX/include/python${PY_VER}m"
 else
     LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}.${DYNAMIC_EXT}"
+    INC_PYTHON="$PREFIX/include/python${PY_VER}"
 fi
 
 cmake .. -LAH                                                                     \
@@ -81,9 +83,9 @@ cmake .. -LAH                                                                   
     -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                            \
     -DBUILD_opencv_python${PY_MAJOR}=1                                            \
     -DPYTHON${PY_MAJOR}_EXECUTABLE=${PYTHON}                                      \
-    -DPYTHON${PY_MAJOR}_INCLUDE_DIR=$PREFIX/include/python${PY_VER}               \
+    -DPYTHON${PY_MAJOR}_INCLUDE_DIR=${INC_PYTHON}                                 \
     -DPYTHON${PY_MAJOR}_NUMPY_INCLUDE_DIRS=${SP_DIR}/numpy/core/include           \
-    -DPYTHON${PY_MAJOR}_LIBRARY=${PREFIX}/lib/libpython${PY_VER}.${DYNAMIC_EXT}   \
+    -DPYTHON${PY_MAJOR}_LIBRARY=${LIB_PYTHON}                                     \
     -DPYTHON${PY_MAJOR}_PACKAGES_PATH=${SP_DIR}
 
 make -j8

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -64,36 +64,27 @@ cmake .. -LAH                                                             \
     -DPYTHON3_LIBRARY=""                                                  \
     -DPYTHON3_PACKAGES_PATH=""
 
-if [ $PY3K -eq 1 ]; then
-    PY_VER_M="${PY_VER}m"
-    LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER_M}.${DYNAMIC_EXT}"
 
-    cmake .. -LAH                                                           \
-        -DPYTHON_EXECUTABLE="${PYTHON}"                                     \
-        -DPYTHON_INCLUDE_DIR="${INC_PYTHON}"                                \
-        -DPYTHON_LIBRARY="${LIB_PYTHON}"                                    \
-        -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                  \
-        -DBUILD_opencv_python3=1                                            \
-        -DPYTHON3_EXECUTABLE=${PYTHON}                                      \
-        -DPYTHON3_NUMPY_INCLUDE_DIRS=${SP_DIR}/numpy/core/include           \
-        -DPYTHON3_INCLUDE_DIR=${PREFIX}/include/python${PY_VER_M}           \
-        -DPYTHON3_LIBRARY=${PREFIX}/lib/libpython${PY_VER_M}.${DYNAMIC_EXT} \
-        -DPYTHON3_PACKAGES_PATH=${SP_DIR}
+IFS='.' read -ra PY_VER_ARR <<< "${PY_VER}"
+PY_MAJOR="${PY_VER_ARR[0]}"
+
+if [ $PY3K -eq 1 ]; then
+    LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}m.${DYNAMIC_EXT}"
 else
     LIB_PYTHON="${PREFIX}/lib/libpython${PY_VER}.${DYNAMIC_EXT}"
-    cmake .. -LAH                                                           \
-        -DPYTHON_EXECUTABLE="${PYTHON}"                                     \
-        -DPYTHON_INCLUDE_DIR="${INC_PYTHON}"                                \
-        -DPYTHON_LIBRARY="${LIB_PYTHON}"                                    \
-        -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                  \
-        -DBUILD_opencv_python2=1                                            \
-        -DPYTHON2_EXECUTABLE=${PYTHON}                                      \
-        -DPYTHON2_INCLUDE_DIR=$PREFIX/include/python${PY_VER}               \
-        -DPYTHON2_NUMPY_INCLUDE_DIRS=${SP_DIR}/numpy/core/include           \
-        -DPYTHON2_LIBRARY=${PREFIX}/lib/libpython${PY_VER}.${DYNAMIC_EXT}   \
-        -DPYTHON_INCLUDE_DIR2=${PREFIX}/include/python${PY_VER}             \
-        -DPYTHON2_PACKAGES_PATH=${SP_DIR}
 fi
+
+cmake .. -LAH                                                                     \
+    -DPYTHON_EXECUTABLE="${PYTHON}"                                               \
+    -DPYTHON_INCLUDE_DIR="${INC_PYTHON}"                                          \
+    -DPYTHON_LIBRARY="${LIB_PYTHON}"                                              \
+    -DPYTHON_PACKAGES_PATH="${SP_DIR}"                                            \
+    -DBUILD_opencv_python${PY_MAJOR}=1                                            \
+    -DPYTHON${PY_MAJOR}_EXECUTABLE=${PYTHON}                                      \
+    -DPYTHON${PY_MAJOR}_INCLUDE_DIR=$PREFIX/include/python${PY_VER}               \
+    -DPYTHON${PY_MAJOR}_NUMPY_INCLUDE_DIRS=${SP_DIR}/numpy/core/include           \
+    -DPYTHON${PY_MAJOR}_LIBRARY=${PREFIX}/lib/libpython${PY_VER}.${DYNAMIC_EXT}   \
+    -DPYTHON${PY_MAJOR}_PACKAGES_PATH=${SP_DIR}
 
 make -j8
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - toolchain
     # For sha256 comparisons of opencv_contrib
-    - openssl
+    - openssl               # [unix]
     # For downloading opencv_contrib
     - curl
     # For applying patches


### PR DESCRIPTION
I think this two passes of CMake was the right idea. Good thinking.

Was still seeing lines that were picking up conda's `root` Python or the system Python on OS X, which were making me pretty nervous. Examples include lines like [this](https://travis-ci.org/conda-forge/opencv-feedstock/jobs/154078616#L1904) or [this](https://travis-ci.org/conda-forge/opencv-feedstock/jobs/154078618#L901-L904). Given we had tried to clamp these down before, I wasn't sure what else we could do. Figured I give this one last try to see what we could. To try and fix it this time, I disabled all Python builds on the first pass. Not only that, but I set every CMake Python variable to an empty string. On the second pass, I just enabled the Python version we were targeting as before. Amazingly this seems to work. Cleaned this up a bit so it looks more like the Windows build and is a bit shorter.

FWICT Windows seems to have the same [problems](https://ci.appveyor.com/project/conda-forge/opencv-feedstock/build/1.0.57/job/wd1hqjee721semd2#L495). So I have tried to implement the same thing there. May try to hunt down a Windows machine to test it on if a working one can be found. If not, we can try another run on AppVeyor.

This is the only concerning issue to me. Everything else I'm more than happy to punt on and deal with after we merge OpenCV.

Please me know your thoughts. 

<br>
xref: https://github.com/conda-forge/opencv-feedstock/pull/16
